### PR TITLE
feat: Add Class Grade Distribution report for teachers

### DIFF
--- a/controllers/faculty/teacher_reports.py
+++ b/controllers/faculty/teacher_reports.py
@@ -1,83 +1,115 @@
 import pandas as pd
 import streamlit as st
 import matplotlib.pyplot as plt
+from pymongo import MongoClient
 
 def class_grade_distribution(db, teacher_name, semester, school_year):
-    st.subheader("📊 Class Grade Distribution")
+    """
+    Generates and displays the Class Grade Distribution report.
+    This report shows the percentage of students falling into different grade brackets
+    for each subject taught by a specific teacher in a given semester and school year.
+    """
+    st.markdown("### 📊 Class Grade Distribution")
+    st.markdown(f"**Faculty Name:** `{teacher_name}`")
+    st.markdown(f"**Semester and School Year:** `{semester}, {school_year}`")
 
-    # Header info
-    st.write(f"**Faculty Name:** {teacher_name}")
-    st.write(f"**Semester and School Year:** {semester}, {school_year}")
+    # Find the semester ID from the semester name and school year
+    semester_doc = db.semesters.find_one({"Semester": semester, "SchoolYear": school_year})
+    if not semester_doc:
+        st.warning("Selected semester and school year combination not found.")
+        return
+    semester_id = semester_doc["_id"]
 
-    # Fetch grades handled by teacher in given term
-    grades_cursor = db["grades"].find({
-        "Teachers": teacher_name,
-        "SemesterID": semester
-    })
+    # Find all subjects taught by the given teacher
+    teacher_subjects_cursor = db.subjects.find({"Teacher": teacher_name})
+    teacher_subject_codes = [s["_id"] for s in teacher_subjects_cursor]
 
-    data = []
-    for g in grades_cursor:
-        subject_codes = g.get("SubjectCodes", [])
-        grades_list = g.get("Grades", [])
-        teachers = g.get("Teachers", [])
+    if not teacher_subject_codes:
+        st.warning(f"No subjects found for teacher: {teacher_name}")
+        return
 
-        for subj, grade in zip(subject_codes, grades_list):
-            # Get subject details
-            subj_doc = db["subjects"].find_one({"_id": subj})
-            subj_name = subj_doc["Description"] if subj_doc else subj
+    # Find all grade entries for the specific semester
+    grades_cursor = db.grades.find({"SemesterID": semester_id})
 
-            # Find row or create new
-            row = next((d for d in data if d["Course Code"] == subj), None)
-            if not row:
-                row = {
-                    "Course Code": subj,
-                    "Course Name": subj_name,
-                    "95-100(%)": 0,
-                    "90-94(%)": 0,
-                    "85-89(%)": 0,
-                    "80-84(%)": 0,
-                    "75-79(%)": 0,
-                    "Below 75(%)": 0,
-                    "Total": 0
-                }
-                data.append(row)
+    report_data = []
 
-            # Count into bins
-            row["Total"] += 1
-            if grade >= 95:
-                row["95-100(%)"] += 1
-            elif grade >= 90:
-                row["90-94(%)"] += 1
-            elif grade >= 85:
-                row["85-89(%)"] += 1
-            elif grade >= 80:
-                row["80-84(%)"] += 1
-            elif grade >= 75:
-                row["75-79(%)"] += 1
-            else:
-                row["Below 75(%)"] += 1
+    # Create a mapping of subject codes to their names for easy lookup
+    subject_details = {s["_id"]: s["Description"] for s in db.subjects.find({"_id": {"$in": teacher_subject_codes}})}
 
-    # Convert to dataframe
-    df = pd.DataFrame(data)
+    # Initialize report structure for all subjects taught by the teacher
+    for code, name in subject_details.items():
+        report_data.append({
+            "Course Code": code,
+            "Course Name": name,
+            "95-100(%)": 0,
+            "90-94 (%)": 0,
+            "85-89 (%)": 0,
+            "80-84(%)": 0,
+            "75-79%": 0,
+            "Below 75(%)": 0,
+            "student_count": 0,
+        })
 
-    # Convert counts to percentages
-    for col in ["95-100(%)","90-94(%)","85-89(%)","80-84(%)","75-79(%)","Below 75(%)"]:
-        df[col] = round((df[col] / df["Total"]) * 100, 2).astype(str) + "%"
+    # Process grades
+    for grade_entry in grades_cursor:
+        student_id = grade_entry.get("StudentID")
+        for i, subject_code in enumerate(grade_entry.get("SubjectCodes", [])):
+            if subject_code in teacher_subject_codes:
+                # Find the corresponding report row
+                report_row = next((item for item in report_data if item["Course Code"] == subject_code), None)
+                if report_row:
+                    grade = grade_entry.get("Grades", [])[i]
+                    report_row["student_count"] += 1
+                    if grade >= 95:
+                        report_row["95-100(%)"] += 1
+                    elif 90 <= grade <= 94:
+                        report_row["90-94 (%)"] += 1
+                    elif 85 <= grade <= 89:
+                        report_row["85-89 (%)"] += 1
+                    elif 80 <= grade <= 84:
+                        report_row["80-84(%)"] += 1
+                    elif 75 <= grade <= 79:
+                        report_row["75-79%"] += 1
+                    else:
+                        report_row["Below 75(%)"] += 1
 
-    df["Total"] = df["Total"].astype(str)  # keep total as count
+    if not any(row['student_count'] > 0 for row in report_data):
+        st.info("No student grade data found for the selected faculty and term.")
+        return
 
-    # Show DataFrame
-    st.dataframe(df)
+    # Create DataFrame and calculate percentages
+    df = pd.DataFrame(report_data)
 
-    # Histogram per subject
-    for _, row in df.iterrows():
-        st.write(f"### {row['Course Code']} - {row['Course Name']}")
+    # Filter out courses with no students
+    df = df[df['student_count'] > 0].copy()
 
-        categories = ["95-100","90-94","85-89","80-84","75-79","Below 75"]
-        values = [float(row[c].replace("%","")) for c in df.columns[2:-1]]
+    grade_cols = ["95-100(%)", "90-94 (%)", "85-89 (%)", "80-84(%)", "75-79%", "Below 75(%)"]
+
+    for col in grade_cols:
+        df[col] = (df[col] / df['student_count'] * 100).round(2)
+
+    df["Total"] = df[grade_cols].sum(axis=1).round(0).astype(str) + '%'
+
+    # Format percentage columns
+    for col in grade_cols:
+        df[col] = df[col].astype(str) + '%'
+
+    st.dataframe(df[["Course Code", "Course Name"] + grade_cols + ["Total"]])
+
+    # --- Display Histogram ---
+    st.markdown("---")
+    st.markdown("### Grade Distribution Histograms")
+
+    for index, row in df.iterrows():
+        st.markdown(f"#### {row['Course Name']} ({row['Course Code']})")
+
+        # Extract numerical values for plotting
+        plot_values = [float(str(row[col]).replace('%','')) for col in grade_cols]
+        plot_labels = [col.replace('(%)','').replace('%','').strip() for col in grade_cols]
 
         fig, ax = plt.subplots()
-        ax.bar(categories, values)
-        ax.set_title(f"Grade Distribution - {row['Course Code']}")
-        ax.set_ylabel("Percentage (%)")
+        ax.bar(plot_labels, plot_values)
+        ax.set_ylabel("Percentage of Students (%)")
+        ax.set_title(f"Grade Distribution for {row['Course Code']}")
+        plt.xticks(rotation=45, ha="right")
         st.pyplot(fig)

--- a/controllers/faculty_controller.py
+++ b/controllers/faculty_controller.py
@@ -104,8 +104,37 @@ def faculty_view(db,user_role):
     if menu == "Class Scheduling":
         from .faculty.class_scheduler_manager import class_scheduler_manager_page
         class_scheduler_manager_page(db)
-    elif menu == "Class Grade Distribution":        
-        pass
+    elif menu == "Class Grade Distribution":
+        from .faculty.teacher_reports import class_grade_distribution
+        from helpers.data_helper import data_helper
+
+        dh = data_helper({"db": db})
+
+        # Get data for filters
+        semesters = dh.get_semester_names()
+        school_years = dh.get_school_years()
+
+        teacher_name = None
+
+        # If the user is a teacher, default to their name.
+        # Otherwise, show a dropdown to select a faculty member.
+        if st.session_state["user_role"] == "teacher":
+            teacher_name = st.session_state["fullname"]
+        else:
+            teachers_df = dh.get_instructor_subjects()
+            teacher_names = teachers_df['Teacher'].unique()
+            teacher_name = st.selectbox("Select Faculty Name", teacher_names)
+
+        # Common filters for semester and school year
+        semester = st.selectbox("Select Semester", semesters)
+        school_year = st.selectbox("Select School Year", school_years)
+
+        # Display the report if a teacher is selected
+        if teacher_name:
+            class_grade_distribution(db, teacher_name, semester, school_year)
+        else:
+            st.warning("Please select a faculty member to view the report.")
+
     elif menu == "Student Progress Tracker":        
         pass
     elif menu == "Subject Difficulty":        


### PR DESCRIPTION
This commit introduces a new report page, "Class Grade Distribution," accessible to users with the 'teacher' role.

The report provides a detailed breakdown of student grades for each subject taught by the logged-in teacher for a selected semester and school year.

Key features include:
- Dropdown filters for semester and school year.
- Automatic filtering by the logged-in teacher's name. For other faculty roles, a dropdown is provided to select a teacher.
- A data table displaying the grade distribution in percentage brackets (e.g., 95-100%, 90-94%, etc.).
- A histogram visualization of the grade distribution for each subject.

The implementation involves:
- A new function `class_grade_distribution` in `controllers/faculty/teacher_reports.py` that contains the data fetching and rendering logic.
- Modifications to `controllers/faculty_controller.py` to integrate the report into the sidebar menu and handle the filter logic.